### PR TITLE
Fix a typo in the GITIGNORE.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 .DS_Store
-sex-tape


### PR DESCRIPTION
This pull request fixes the false inclusion of important assets in the `.gitignore` that might have been unintentionally added by an external program. As a result of this issue, this project does not function properly.

This also closes #1.